### PR TITLE
Make Warrant Great again

### DIFF
--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -53,6 +54,8 @@ var _ = BeforeSuite(func() {
 
 	adminClient.Authorities = append(adminClient.Authorities, "password.write")
 	adminClient.Authorities = append(adminClient.Authorities, "uaa.resource")
+	adminClient.AuthorizedGrantTypes = append(adminClient.AuthorizedGrantTypes, "password")
+	adminClient.AccessTokenValidity = time.Duration(2) * time.Hour
 	err = warrantClient.Clients.Update(adminClient, UAAToken)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -47,4 +47,13 @@ var _ = BeforeSuite(func() {
 	var err error
 	UAAToken, err = warrantClient.Clients.GetToken(UAAAdminClient, UAAAdminSecret)
 	Expect(err).NotTo(HaveOccurred())
+	//Add more power to the client
+	adminClient, err := warrantClient.Clients.Get(UAAAdminClient, UAAToken)
+	Expect(err).NotTo(HaveOccurred())
+
+	adminClient.Authorities = append(adminClient.Authorities, "password.write")
+	adminClient.Authorities = append(adminClient.Authorities, "uaa.resource")
+	err = warrantClient.Clients.Update(adminClient, UAAToken)
+	Expect(err).NotTo(HaveOccurred())
+
 })

--- a/acceptance/tokens_test.go
+++ b/acceptance/tokens_test.go
@@ -1,7 +1,6 @@
 package acceptance
 
 import (
-	"encoding/pem"
 	"time"
 
 	"github.com/pivotal-cf-experimental/warrant"
@@ -126,10 +125,7 @@ var _ = Describe("Tokens", func() {
 			signingKey, err := warrantClient.Tokens.GetSigningKey(UAAAdminClient, UAAAdminSecret)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(signingKey.Algorithm).To(Equal("HMACSHA256"))
-
-			block, _ := pem.Decode([]byte(signingKey.Value))
-			Expect(block).NotTo(BeNil())
-			Expect(block.Type).To(Equal("PUBLIC KEY"))
+			Expect(signingKey.Value).To(Equal("tokenkey"))
 		})
 	})
 })

--- a/acceptance/tokens_test.go
+++ b/acceptance/tokens_test.go
@@ -123,9 +123,9 @@ var _ = Describe("Tokens", func() {
 
 	Context("fetching the signing key", func() {
 		It("can fetch a valid signing key from the server", func() {
-			signingKey, err := warrantClient.Tokens.GetSigningKey()
+			signingKey, err := warrantClient.Tokens.GetSigningKey(UAAAdminClient, UAAAdminSecret)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(signingKey.Algorithm).To(Equal("SHA256withRSA"))
+			Expect(signingKey.Algorithm).To(Equal("HMACSHA256"))
 
 			block, _ := pem.Decode([]byte(signingKey.Value))
 			Expect(block).NotTo(BeNil())

--- a/acceptance/tokens_test.go
+++ b/acceptance/tokens_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Tokens", func() {
 		)
 
 		BeforeEach(func() {
-			scopes = []string{"notification_preferences.read", "notification_preferences.write"}
+			scopes = []string{"scim.me"}
 			client = warrant.Client{
 				ID:                   UAADefaultClientID,
 				Scope:                scopes,

--- a/acceptance/user_lifecycle_test.go
+++ b/acceptance/user_lifecycle_test.go
@@ -41,7 +41,7 @@ var _ = Describe("User Lifecycle", func() {
 			Expect(user.UpdatedAt).To(BeTemporally("~", time.Now().UTC(), 10*time.Minute))
 			Expect(user.Version).To(Equal(0))
 			Expect(user.Active).To(BeTrue())
-			Expect(user.Verified).To(BeFalse())
+			Expect(user.Verified).To(BeTrue())
 			Expect(user.Origin).To(Equal("uaa"))
 			//Expect(user.Groups).To(ConsistOf([]warrant.Group{})) TODO: finish up groups implementation
 		})

--- a/tokens_service.go
+++ b/tokens_service.go
@@ -60,10 +60,11 @@ func (ts TokensService) Decode(token string) (Token, error) {
 
 // GetSigningKey makes a request to UAA to retrieve the SigningKey used to
 // generate valid tokens.
-func (ts TokensService) GetSigningKey() (SigningKey, error) {
+func (ts TokensService) GetSigningKey(id, secret string) (SigningKey, error) {
 	resp, err := newNetworkClient(ts.config).MakeRequest(network.Request{
-		Method: "GET",
-		Path:   "/token_key",
+		Method:        "GET",
+		Authorization: network.NewBasicAuthorization(id, secret),
+		Path:          "/token_key",
 		AcceptableStatusCodes: []int{http.StatusOK},
 	})
 	if err != nil {

--- a/tokens_service_test.go
+++ b/tokens_service_test.go
@@ -66,7 +66,7 @@ var _ = Describe("TokensService", func() {
 
 	Describe("GetSigningKey", func() {
 		It("returns the public key, used to sign tokens", func() {
-			key, err := service.GetSigningKey()
+			key, err := service.GetSigningKey("id", "secret")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(key).To(Equal(warrant.SigningKey{
 				Algorithm: "SHA256withRSA",
@@ -86,7 +86,7 @@ var _ = Describe("TokensService", func() {
 					TraceWriter:   TraceWriter,
 				})
 
-				_, err := service.GetSigningKey()
+				_, err := service.GetSigningKey("id", "secret")
 				Expect(err).To(BeAssignableToTypeOf(warrant.UnexpectedStatusError{}))
 			})
 
@@ -101,7 +101,7 @@ var _ = Describe("TokensService", func() {
 					TraceWriter:   TraceWriter,
 				})
 
-				_, err := service.GetSigningKey()
+				_, err := service.GetSigningKey("id", "secret")
 				Expect(err).To(BeAssignableToTypeOf(warrant.MalformedResponseError{}))
 				Expect(err).To(MatchError("malformed response: invalid character 'h' in literal true (expecting 'r')"))
 			})


### PR DESCRIPTION
In an  attempt to make the acceptance test pass again.

Fixes
1. `/token_key` is protected using basic auth . See https://github.com/cloudfoundry/uaa/issues/92 for more details
2. New Users are verified by default
[wiki](https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst#create-a-user-post-users)
3. `notification_preferences.read`  is not really the OS scope, `scim.me` is 
4. UAA is deployed with `HMACSHA256`  as default [algorithm](https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst#get-the-token-signing-key-get-token_key) --> This I am not sure on how and why , But thing that I just observed
